### PR TITLE
fix: prevent horizontal scroll on mobile

### DIFF
--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -116,10 +116,12 @@ code {
 
     table {
         border-collapse: collapse;
-        min-width: 95%;
+        width: 100%;
+        max-width: 100%;
         display: block;
         overflow-x: auto;
-        margin: 0 auto 1em auto;
+        -webkit-overflow-scrolling: touch;
+        margin: 0 0 1em 0;
     }
 
     td {
@@ -195,6 +197,7 @@ code {
 .listItemTagsList {
     display: flex;
     gap: 10px;
+    flex-wrap: wrap;
 }
 
 .listItemTag {
@@ -273,6 +276,7 @@ h5 {
     display: flex;
     align-items: center;
     gap: 15px;
+    flex-wrap: wrap;
 }
 
 .singlePostTag {

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -116,12 +116,10 @@ code {
 
     table {
         border-collapse: collapse;
-        width: 100%;
-        max-width: 100%;
-        display: block;
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        margin: 0 0 1em 0;
+        min-width: 95%;
+        max-width: 95%;
+        display: table;
+        margin: 0 auto 1em auto;
     }
 
     td {
@@ -340,6 +338,15 @@ h5 {
 }
 
 @media only screen and (max-width: 540px) {
+    .container table {
+        width: 100%;
+        max-width: 100%;
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        margin: 0 0 1em 0;
+    }
+
     .footer {
         margin-top: 20px;
         flex-direction: column;

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -135,8 +135,7 @@ code {
     }
 
     th {
-        padding-top: 12px;
-        padding-bottom: 12px;
+        padding: 12px 10px;
         text-align: left;
         background-color: var(--primary);
     }

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -55,6 +55,7 @@ code {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    overflow-wrap: break-word;
 
     font-size: 17px;
     line-height: 1.7em;
@@ -116,8 +117,8 @@ code {
     table {
         border-collapse: collapse;
         min-width: 95%;
-        max-width: 95%;
-        display: table;
+        display: block;
+        overflow-x: auto;
         margin: 0 auto 1em auto;
     }
 


### PR DESCRIPTION
## Summary
- Add `overflow-x: hidden` to html element to prevent page-level horizontal scroll
- Make tables horizontally scrollable with `display: block; overflow-x: auto` instead of overflowing the page
- Fixes mobile Safari horizontal scroll caused by tables with long content (wallet addresses)

## Test plan
- [ ] Open on mobile Safari and verify no horizontal page scroll
- [ ] Verify tables with long content scroll horizontally within their container
- [ ] Verify code blocks still scroll horizontally as expected